### PR TITLE
Implemented omission of attributes from filtering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ The magic 🧙happens in `renderResults`, which returns an array of objects. You
 
 Filtering logic will iterate over any level of nesting in your data structure. Which means a good suggestion for this is something like user data or todo items that aren't heavily nested at many levels.
 
+If you wish to exclude a field from filtering logic, simply provide it as a prop `omit`
+```javascript
+// if each object is of the form
+var obj = {a: 'a', b: 'b', c: {b: 'b', d: {b: 'b', f: 'f'}}};
+<SearchResults
+  ...
+  omit={['c.d.b', 'f']}
+  ...
+/>
+// your objects will be filtered only with these fields => { a: 'a', b: 'b', c: { b: 'b', d: {} } }
+// but you can still render other values
+```
+
 To render your data, simply use .map() to render to the view--the data retains in the same structure. Return some inline JSX, or feed each element into a stateless React component that renders some UI.
 
 ## `props`
@@ -94,6 +107,7 @@ To render your data, simply use .map() to render to the view--the data retains i
 | `value`          | `string`             | `true`   |    
 | `data`           | `array` of `object`s | `true`   |
 | `reunderResults` | `func`               | `true`   |
+| `omit`           | `array` of `string`s | `false`  |
 
 
 ## Contributions

--- a/demo2/src/index.js
+++ b/demo2/src/index.js
@@ -1,0 +1,72 @@
+// in this demo we demonstrate that an attribute can be rendered but still not be use for filtering
+
+import React, { Component } from 'react';
+import { render } from 'react-dom';
+
+import SearchResults from '../../src';
+
+class Demo extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: [],
+      value: ''
+    };
+  }
+  componentWillMount() {
+    fetch('https://jsonplaceholder.typicode.com/users')
+      .then(response => response.json())
+      .then(
+        json => this.setState({ data: json }));
+  }
+  handleChange = event => {
+    const { value } = event.target;
+    this.setState({ value });
+  };
+  render() {
+    const { data, value } = this.state;
+    return (
+      <div>
+        <input type="text" value={value} onChange={this.handleChange} />
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gridGap: '16px',
+            padding: '16px'
+          }}
+        >
+          <SearchResults
+            value={value}
+            data={data}
+            omit={['address.city', 'address.street']}
+            renderResults={results => (
+              <div style={{ marginTop: '16px' }}>
+                {results.map((data , i) => (
+                  <div
+                    key={i}
+                    style={{
+                      backgroundColor: '#f7f7f7',
+                      marginBottom: '8px',
+                      borderRadius: '4px',
+                      padding: '16px',
+                      alignSelf: 'start',
+                      width: '100%'
+                    }}
+                  >
+                    <span>{data.name + " " + data.address.city}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          />
+          <pre>
+            <code>{JSON.stringify(data, null, 2)}</code>
+          </pre>
+        </div>
+      </div>
+    );
+  }
+}
+
+render(<Demo />, document.querySelector('#demo'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -5181,8 +5181,7 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
@@ -6528,7 +6527,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -6536,8 +6534,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -6641,8 +6638,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -8841,6 +8837,56 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "omit-deep": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/omit-deep/-/omit-deep-0.3.0.tgz",
+      "integrity": "sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=",
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "unset-value": "^0.1.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "unset-value": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
+          "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          }
+        }
+      }
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server"
   },
-  "dependencies": {},
+  "dependencies": {
+    "omit-deep": "^0.3.0"
+  },
   "peerDependencies": {
     "react": "16.x"
   },

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,3 +1,5 @@
+import omitDeep from 'omit-deep';
+
 function strOp(str) {
   return str
     .toString()
@@ -5,8 +7,8 @@ function strOp(str) {
     .toLowerCase();
 }
 
-function objectValues(value) {
-  return Object.values(value).reduce((string, val) => {
+function objectValues(value, omit) {
+  return Object.values(omitDeep(JSON.parse(JSON.stringify(value)), omit)).reduce((string, val) => {
     const test = val !== null && val !== undefined;
     return (
       string +
@@ -17,8 +19,8 @@ function objectValues(value) {
   }, '');
 }
 
-export function filter(val, data) {
+export function filter(val, data, omit) {
   return data.filter(el => {
-    return !!val.length ? objectValues(el).includes(strOp(val)) : true;
+    return !!val.length ? objectValues(el, omit).includes(strOp(val)) : true;
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,14 @@ import { filter } from './filter';
 
 export default class FilterResults extends Component {
   render() {
-    const { value, data } = this.props;
-    return this.props.renderResults(filter(value, data));
+    const { value, data, omit = [] } = this.props;
+    return this.props.renderResults(filter(value, data, omit));
   }
 }
 
 FilterResults.propTypes = {
   value: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  renderResults: PropTypes.func.isRequired
+  renderResults: PropTypes.func.isRequired,
+  omit: PropTypes.arrayOf(PropTypes.string)
 };


### PR DESCRIPTION
Hey! I was using your package and realised that the usability of this module would greatly improve if there was way to exclude certain fields from filtering logic or be able to cherry-pick fields. 

So here is my attempt at contributing to this package:

If you wish to exclude a field from filtering logic, simply provide it as a prop `omit`
```javascript
// if each object is of the form
var obj = {a: 'a', b: 'b', c: {b: 'b', d: {b: 'b', f: 'f'}}};
<SearchResults
  ...
  omit={['c.d.b', 'f']}
  ...
/>
// your objects will be filtered only with these fields 
// => { a: 'a', b: 'b', c: { b: 'b', d: {} } } 
// but you can still render all values present in the original object
```

I shall attempt to implement the cherry-picking using [js-nested-pick](https://www.npmjs.com/package/js-nested-pick). Until then I hope my contribution will be accepted to make this even better.